### PR TITLE
Fixed broken links

### DIFF
--- a/js/projects.js
+++ b/js/projects.js
@@ -18,7 +18,7 @@ fetch(jsonFilePath)
 
         var header = document.createElement("a");
         header.className = "project-item-title";
-        header.href = `${p.link}`;
+        header.href = `${p.source}`;
         header.textContent = `${p.title}`;
 
         var year = document.createElement("h4");


### PR DESCRIPTION
Fixed broken links in JS code. Selector was looking for `link` vs `source` 